### PR TITLE
[PORT-15] Added global colors and tokens

### DIFF
--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -1,0 +1,9 @@
+import "./src/styles/global.css";
+
+// Add provider/s later
+const wrapRootElement = ({ children }) => {
+  return { children };
+};
+
+// Syntax required by gatsby browser api - don't export pls
+wrapRootElement;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
-import { Link, type HeadFC } from "gatsby";
+import { type HeadFC } from "gatsby";
 import * as React from "react";
+import "../styles/index.css";
 
 const IndexPage = () => {
   return (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,35 @@
+:root {
+  /* Default Tokens */
+  --primary-color: var(--dark-grey);
+  --background-color: var(--gradient-background);
+  --element-background-color: var(--off-white);
+
+  /* Colors */
+  --off-white: #faf9f6;
+  --dark-grey: #2c2c2c;
+  --charcoal: #242424;
+  --darkest-grey: #1c1c1c;
+  --gradient-primary: var(--off-white);
+  --gradient-secondary: #d1e9f6;
+  --gradient-background: linear-gradient(
+    var(--gradient-primary),
+    var(--gradient-secondary)
+  );
+}
+
+body,
+h1 {
+  margin: 0;
+}
+
+p,
+h1,
+h2,
+h3 {
+  color: var(--primary-color);
+}
+
+main {
+  background: var(--gradient-background);
+  min-height: 100vh;
+}


### PR DESCRIPTION
This pull request introduces global styles and updates the main page to use these styles in a Gatsby project. The most important changes include adding a global CSS file, updating the root element to import the new styles, and defining CSS variables for consistent theming.

Styling improvements:
* [`src/styles/global.css`](diffhunk://#diff-03cc26efc9f06a95cd86aef185af462b72cc9d548a58177f8972837895f2de9eR1-R35): Defined CSS variables for colors and background gradients, and set default styles for body and heading elements.